### PR TITLE
Replace magic strings with a proper TileType enum

### DIFF
--- a/Scrabble2018/Controller/GameController.cs
+++ b/Scrabble2018/Controller/GameController.cs
@@ -1,9 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.IO;
-using System.Text;
-using System.Threading.Tasks;
 using Scrabble2018.Model;
 using Scrabble2018.Model.Word;
 using Scrabble2018.View;
@@ -82,12 +78,21 @@ namespace Scrabble2018.Controller
 
         public SolidColorBrush UpdateColor(int i, int j)
         {
-            if (gs.boardTiles.PlaceInUse[i, j] == "tw") return Brushes.OrangeRed;
-            else if (gs.boardTiles.PlaceInUse[i, j] == "dw") return Brushes.Coral;
-            else if (gs.boardTiles.PlaceInUse[i, j] == "dl") return Brushes.LightSkyBlue;
-            else if (gs.boardTiles.PlaceInUse[i, j] == "tl") return Brushes.MediumBlue;
-            else if (gs.boardTiles.PlaceInUse[i, j] == "st") return Brushes.Gold;
-            else return Brushes.Bisque;
+            switch (gs.boardTiles.PlaceInUse[i, j])
+            {
+                case TileType.WordTriple:
+                    return Brushes.OrangeRed;
+                case TileType.WordDouble:
+                    return Brushes.Coral;
+                case TileType.LetterDouble:
+                    return Brushes.LightSkyBlue;
+                case TileType.LetterTriple:
+                    return Brushes.MediumBlue;
+                case TileType.Start:
+                    return Brushes.Gold;
+                default:
+                    return Brushes.Bisque;
+            }
         }
 
     }

--- a/Scrabble2018/Model/Tile/BoardTile.cs
+++ b/Scrabble2018/Model/Tile/BoardTile.cs
@@ -1,38 +1,50 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows.Media;
+﻿using System.Windows.Media;
 
 namespace Scrabble2018
 {
+    public enum TileType
+    {
+        Default,
+        LetterDouble,
+        LetterTriple,
+        WordDouble,
+        WordTriple,
+        Start
+    }
+
     public class BoardTiles
     {
+        private const TileType __ = TileType.Default;
+        private const TileType DL = TileType.LetterDouble;
+        private const TileType TL = TileType.LetterTriple;
+        private const TileType DW = TileType.WordDouble;
+        private const TileType TW = TileType.WordTriple;
+        private const TileType ST = TileType.Start;
+
         // Reference BoardTiles and utility
         // Reference is for cancelling used colors
-        public static string[,] Placement = new string[15, 15]
+        public static TileType[,] Placement = 
         {
-            {"tw","","","dl","","","","tw","","","","dl","","","tw"},
-            {"","dw","","","","tl","","","","tl","","","","dw",""},
-            {"","","dw","","","","dl","","dl","","","","dw","",""},
-            {"dl","","","dw","","","","dl","","","","dw","","","dl"},
-            {"","","","","dw","","","","","","dw","","","","" },
-            {"","tl","","","","tl","","","","tl","","","","tl",""},
-            {"","","dl","","","","dl","","dl","","","","dl","",""},
-            //middle
-            {"tw","","","dl","","","","st","","","","dl","","","tl"},
-            //middle
-            {"","","dl","","","","dl","","dl","","","","dl","",""},
-            {"","tl","","","","tl","","","","tl","","","","tl",""},
-            {"","","","","dw","","","","","","dw","","","","" },
-            {"dl","","","dw","","","","dl","","","","dw","","","dl"},
-            {"","","dw","","","","dl","","dl","","","","dw","",""},
-            { "","dw","","","","tl","","","","tl","","","","dw",""},
-            {"tw","","","dl","","","","tw","","","","dl","","","tw"}
+            {TW,__,__,DL,__,__,__,TW,__,__,__,DL,__,__,TW},
+            {__,DW,__,__,__,TL,__,__,__,TL,__,__,__,DW,__},
+            {__,__,DW,__,__,__,DL,__,DL,__,__,__,DW,__,__},
+            {DL,__,__,DW,__,__,__,DL,__,__,__,DW,__,__,DL},
+            {__,__,__,__,DW,__,__,__,__,__,DW,__,__,__,__ },
+            {__,TL,__,__,__,TL,__,__,__,TL,__,__,__,TL,__},
+            {__,__,DL,__,__,__,DL,__,DL,__,__,__,DL,__,__},
+            //midDLe
+            {TW,__,__,DL,__,__,__,ST,__,__,__,DL,__,__,TL},
+            //midDLe
+            {__,__,DL,__,__,__,DL,__,DL,__,__,__,DL,__,__},
+            {__,TL,__,__,__,TL,__,__,__,TL,__,__,__,TL,__},
+            {__,__,__,__,DW,__,__,__,__,__,DW,__,__,__,__ },
+            {DL,__,__,DW,__,__,__,DL,__,__,__,DW,__,__,DL},
+            {__,__,DW,__,__,__,DL,__,DL,__,__,__,DW,__,__},
+            { __,DW,__,__,__,TL,__,__,__,TL,__,__,__,DW,__},
+            {TW,__,__,DL,__,__,__,TW,__,__,__,DL,__,__,TW}
         };
 
-        public string[,] PlaceInUse;
+        public TileType[,] PlaceInUse;
         private bool[,] Visited;
 
         public BoardTiles()
@@ -41,34 +53,34 @@ namespace Scrabble2018
             Visited = new bool[15, 15];
         }
 
-        public int WordMultiplier(int i,int j)
+        public int WordMultiplier(int i, int j)
         {
-            if (PlaceInUse[i, j] == "tw")
+            switch (PlaceInUse[i, j])
             {
-                Visited[i, j] = true;
-                return 3;
+                case TileType.WordTriple:
+                    Visited[i, j] = true;
+                    return 3;
+                case TileType.WordDouble:
+                    Visited[i, j] = true;
+                    return 2;
+                default:
+                    return 1;
             }
-            else if (PlaceInUse[i, j] == "dw")
-            {
-                Visited[i, j] = true;
-                return 2;
-            }
-            else return 1;
         }
 
         public int LetterMultiplier(int i, int j)
         {
-            if (PlaceInUse[i, j] == "tl")
+            switch (PlaceInUse[i, j])
             {
-                Visited[i, j] = true;
-                return 3;
+                case TileType.LetterTriple:
+                    Visited[i, j] = true;
+                    return 3;
+                case TileType.LetterDouble:
+                    Visited[i, j] = true;
+                    return 2;
+                default:
+                    return 1;
             }
-            else if (PlaceInUse[i, j] == "dl")
-            {
-                Visited[i, j] = true;
-                return 2;
-            }
-            else return 1;
         }
 
         public void ApplyVisited()
@@ -79,7 +91,7 @@ namespace Scrabble2018
                 {
                     if (Visited[i, j])
                     {
-                        PlaceInUse[i, j] = "";
+                        PlaceInUse[i, j] = TileType.Default;
                         Visited[i, j] = false;
                     }
                 }
@@ -100,12 +112,21 @@ namespace Scrabble2018
 
         public static SolidColorBrush DetermineColor(int i, int j)
         {
-            if (Placement[i, j] == "tw") return Brushes.OrangeRed;
-            else if (Placement[i, j] == "dw") return Brushes.Coral;
-            else if (Placement[i, j] == "dl") return Brushes.LightSkyBlue;
-            else if (Placement[i, j] == "tl") return Brushes.MediumBlue;
-            else if (Placement[i, j] == "st") return Brushes.Gold;
-            else return Brushes.Bisque;
+            switch (Placement[i, j])
+            {
+                case TileType.WordTriple:
+                    return Brushes.OrangeRed;
+                case TileType.WordDouble:
+                    return Brushes.Coral;
+                case TileType.LetterDouble:
+                    return Brushes.LightSkyBlue;
+                case TileType.LetterTriple:
+                    return Brushes.MediumBlue;
+                case TileType.Start:
+                    return Brushes.Gold;
+                default:
+                    return Brushes.Bisque;
+            }
         }
 
 


### PR DESCRIPTION
This is less error prone and more readable in code as it's not possible to use invalid states for a field.