### PR TITLE
Fix help modal display  and added mobile help window

### DIFF
--- a/Scrabble/Scrabble.csproj
+++ b/Scrabble/Scrabble.csproj
@@ -80,8 +80,11 @@
     <Compile Include="View\BlankTileForm.xaml.cs">
       <DependentUpon>BlankTileForm.xaml</DependentUpon>
     </Compile>
-    <Compile Include="View\HelpWindow.xaml.cs">
-      <DependentUpon>HelpWindow.xaml</DependentUpon>
+    <Compile Include="View\MobileHelpWindow.xaml.cs">
+      <DependentUpon>MobileHelpWindow.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="View\DesktopHelpWindow.xaml.cs">
+      <DependentUpon>DesktopHelpWindow.xaml</DependentUpon>
     </Compile>
     <Compile Include="View\TextWindow.xaml.cs">
       <DependentUpon>TextWindow.xaml</DependentUpon>
@@ -101,7 +104,11 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
-    <Page Include="View\HelpWindow.xaml">
+    <Page Include="View\MobileHelpWindow.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="View\DesktopHelpWindow.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/Scrabble/View/DesktopHelpWindow.xaml
+++ b/Scrabble/View/DesktopHelpWindow.xaml
@@ -1,0 +1,17 @@
+﻿<Window x:Class="Scrabble.View.DesktopHelpWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:Scrabble.View"
+        mc:Ignorable="d"
+        ResizeMode="CanMinimize"
+        Title="Board Tile Types" Height="100" Width="300">
+    <Grid>
+        <Button Content="3xWord" Background="OrangeRed" HorizontalAlignment="Left" Margin="10,10,0,0" VerticalAlignment="Top" Width="50" Height="50"/>
+        <Button Content="2xWord" Background="Coral" HorizontalAlignment="Left" Margin="80,10,0,0" VerticalAlignment="Top" Width="50" Height="50"/>
+        <Button Content="3xLetter" Background="MediumBlue"  HorizontalAlignment="Left" Margin="150,10,0,0" VerticalAlignment="Top" Width="50" Height="50"/>
+        <Button Content="2xLetter" Background="LightSkyBlue"  HorizontalAlignment="Left" Margin="220,10,0,0" VerticalAlignment="Top" Width="50" Height="50"/>
+
+    </Grid>
+</Window>

--- a/Scrabble/View/DesktopHelpWindow.xaml.cs
+++ b/Scrabble/View/DesktopHelpWindow.xaml.cs
@@ -1,0 +1,14 @@
+﻿using System.Windows;
+
+namespace Scrabble.View
+{
+    public partial class DesktopHelpWindow : Window
+    {
+        public DesktopHelpWindow()
+        {
+            InitializeComponent();
+            WindowStartupLocation = System.Windows.WindowStartupLocation.CenterScreen;
+            Topmost = true;
+        }
+    }
+}

--- a/Scrabble/View/DesktopWindow.xaml
+++ b/Scrabble/View/DesktopWindow.xaml
@@ -6,7 +6,7 @@
         mc:Ignorable="d"
         Title="Scrabble" Height="720" Width="1280"
         Background="AntiqueWhite" 
-        ResizeMode="CanMinimize"
+        Topmost="False"      
         KeyDown="Window_KeyDown"
         >
 

--- a/Scrabble/View/DesktopWindow.xaml.cs
+++ b/Scrabble/View/DesktopWindow.xaml.cs
@@ -8,6 +8,9 @@ using Scrabble.View;
 using Scrabble.Model;
 using Scrabble.Controller;
 using Scrabble.Model.Game;
+using System.Linq;
+using System.Diagnostics;
+
 
 namespace Scrabble
 {
@@ -25,6 +28,7 @@ namespace Scrabble
         {
             InitializeComponent();
             ThisPlayer = P;
+           this.Topmost= false;
             game = g;
             game.Subs(this);
             GameState.GSInstance.OnStateChanged += OnStateChanged;
@@ -378,10 +382,30 @@ namespace Scrabble
             }
         }
 
-        private void HelpButton_Click(object sender, RoutedEventArgs e)
+        private async void HelpButton_Click(object sender, RoutedEventArgs e)
         {
-            HelpWindow hw = new HelpWindow();
-            hw.ShowDialog();
+            bool isfound = false;
+            foreach (var item in Application.Current.Windows)
+            {
+                Debug.WriteLine(item.GetType());
+                if (item.GetType()==typeof(HelpWindow))
+                {
+                    ((HelpWindow)item).Topmost=false;
+                    ((HelpWindow)item).Topmost = true;
+                    return;
+                }
+            }
+            if (!isfound)
+            {
+                HelpWindow hw = new HelpWindow();
+                hw.Show();
+            }
+               
+            
+           
+           
+        
         }
+    
     }
 }

--- a/Scrabble/View/DesktopWindow.xaml.cs
+++ b/Scrabble/View/DesktopWindow.xaml.cs
@@ -388,16 +388,18 @@ namespace Scrabble
             foreach (var item in Application.Current.Windows)
             {
                 Debug.WriteLine(item.GetType());
-                if (item.GetType()==typeof(HelpWindow))
+                if (item.GetType()==typeof(DesktopHelpWindow))
                 {
-                    ((HelpWindow)item).Topmost=false;
-                    ((HelpWindow)item).Topmost = true;
+                    ((DesktopHelpWindow)item).Top = (System.Windows.SystemParameters.WorkArea.Height / 2)-(((DesktopHelpWindow)item).Height/2);
+                    ((DesktopHelpWindow)item).Left = (System.Windows.SystemParameters.WorkArea.Width / 2) - (((DesktopHelpWindow)item).Width / 2); 
+                    ((DesktopHelpWindow)item).Topmost=false;
+                    ((DesktopHelpWindow)item).Topmost = true;
                     return;
                 }
             }
             if (!isfound)
             {
-                HelpWindow hw = new HelpWindow();
+                DesktopHelpWindow hw = new DesktopHelpWindow();
                 hw.Show();
             }
                

--- a/Scrabble/View/HelpWindow.xaml.cs
+++ b/Scrabble/View/HelpWindow.xaml.cs
@@ -7,6 +7,8 @@ namespace Scrabble.View
         public HelpWindow()
         {
             InitializeComponent();
+            WindowStartupLocation = System.Windows.WindowStartupLocation.CenterScreen;
+            Topmost = true;
         }
     }
 }

--- a/Scrabble/View/MobileHelpWindow.xaml
+++ b/Scrabble/View/MobileHelpWindow.xaml
@@ -8,10 +8,10 @@
         ResizeMode="CanMinimize"
         Title="Board Tile Types" Height="200" Width="150">
     <Grid>
-        <Button Content="3xWord" Background="OrangeRed" HorizontalAlignment="Left" Margin="10,10,0,0" VerticalAlignment="Top" Width="50" Height="50"/>
-        <Button Content="2xWord" Background="Coral" HorizontalAlignment="Left" Margin="80,10,0,0" VerticalAlignment="Top" Width="50" Height="50"/>
-        <Button Content="3xLetter" Background="MediumBlue"  HorizontalAlignment="Left" Margin="10,80,0,0" VerticalAlignment="Top" Width="50" Height="50"/>
-        <Button Content="2xLetter" Background="LightSkyBlue"  HorizontalAlignment="Left" Margin="81,79,0,0" VerticalAlignment="Top" Width="50" Height="50"/>
+        <Button ToolTip="Covering this tile will get 3 times word score" Content="3xWord" Background="OrangeRed" HorizontalAlignment="Left" Margin="10,10,0,0" VerticalAlignment="Top" Width="50" Height="50"/>
+        <Button Content="2xWord" ToolTip="Covering this tile will get 2 times word score" Background="Coral" HorizontalAlignment="Left" Margin="80,10,0,0" VerticalAlignment="Top" Width="50" Height="50"/>
+        <Button Content="3xLetter" ToolTip="Covering this tile will get 3 times the letter score" Background="MediumBlue"  HorizontalAlignment="Left" Margin="10,80,0,0" VerticalAlignment="Top" Width="50" Height="50"/>
+        <Button Content="2xLetter" ToolTip="Covering this tile will get 2 times the letter score" Background="LightSkyBlue"  HorizontalAlignment="Left" Margin="81,79,0,0" VerticalAlignment="Top" Width="50" Height="50"/>
 
     </Grid>
 </Window>

--- a/Scrabble/View/MobileHelpWindow.xaml
+++ b/Scrabble/View/MobileHelpWindow.xaml
@@ -1,4 +1,4 @@
-﻿<Window x:Class="Scrabble.View.HelpWindow"
+﻿<Window x:Class="Scrabble.View.MobileHelpWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -6,12 +6,12 @@
         xmlns:local="clr-namespace:Scrabble.View"
         mc:Ignorable="d"
         ResizeMode="CanMinimize"
-        Title="Board Tile Types" Height="100" Width="300">
+        Title="Board Tile Types" Height="200" Width="150">
     <Grid>
         <Button Content="3xWord" Background="OrangeRed" HorizontalAlignment="Left" Margin="10,10,0,0" VerticalAlignment="Top" Width="50" Height="50"/>
         <Button Content="2xWord" Background="Coral" HorizontalAlignment="Left" Margin="80,10,0,0" VerticalAlignment="Top" Width="50" Height="50"/>
-        <Button Content="3xLetter" Background="MediumBlue"  HorizontalAlignment="Left" Margin="150,10,0,0" VerticalAlignment="Top" Width="50" Height="50"/>
-        <Button Content="2xLetter" Background="LightSkyBlue"  HorizontalAlignment="Left" Margin="220,10,0,0" VerticalAlignment="Top" Width="50" Height="50"/>
+        <Button Content="3xLetter" Background="MediumBlue"  HorizontalAlignment="Left" Margin="10,80,0,0" VerticalAlignment="Top" Width="50" Height="50"/>
+        <Button Content="2xLetter" Background="LightSkyBlue"  HorizontalAlignment="Left" Margin="81,79,0,0" VerticalAlignment="Top" Width="50" Height="50"/>
 
     </Grid>
 </Window>

--- a/Scrabble/View/MobileHelpWindow.xaml.cs
+++ b/Scrabble/View/MobileHelpWindow.xaml.cs
@@ -2,9 +2,9 @@
 
 namespace Scrabble.View
 {
-    public partial class HelpWindow : Window
+    public partial class MobileHelpWindow : Window
     {
-        public HelpWindow()
+        public MobileHelpWindow()
         {
             InitializeComponent();
             WindowStartupLocation = System.Windows.WindowStartupLocation.CenterScreen;

--- a/Scrabble/View/MobileWindow.xaml
+++ b/Scrabble/View/MobileWindow.xaml
@@ -14,7 +14,7 @@
         <Button x:Name="ValidateButton"  FontSize="15" Background="Green" Foreground="White" IsEnabled="True" Content="DONE" HorizontalAlignment="Left" Margin="130,243,0,0" VerticalAlignment="Top" Width="50" Height="24" Click="ValidateButton_Click"/>
         <Button x:Name="SwapButton" FontSize="15" Background="Tomato" Foreground="White" IsEnabled="True" Content="SWAP" HorizontalAlignment="Left" Margin="12,243,0,0" VerticalAlignment="Top" Width="50" Height="24" Click="SwapButton_Click"/>
         <Button x:Name="ReloadButton" FontSize="15" Background="PaleVioletRed" Foreground="White" IsEnabled="True" Content="RELOAD" HorizontalAlignment="Left" Margin="67,243,0,0" VerticalAlignment="Top" Width="58" Height="24" Click="ReloadButton_Click"/>
-        <Button x:Name="HelpButton" Width="25" Height="24" FontSize="15" Background="Blue" Foreground="White" Margin="180,243,30,0" IsEnabled="True" VerticalAlignment="Top" FontFamily="Segoe MDL2 Assets" Content="&#xE897;" RenderTransformOrigin="1.9,-1.965" Click="HelpButton_Click"/>
+        <Button x:Name="HelpButton" Width="25" Height="24" FontSize="15" Background="Blue" Foreground="White" Margin="185,243,30,0" IsEnabled="True" VerticalAlignment="Top" FontFamily="Segoe MDL2 Assets" Content="&#xE897;" RenderTransformOrigin="1.9,-1.965" Click="HelpButton_Click"/>
         <UniformGrid x:Name="BoardGrid" Columns="15" Rows="15" HorizontalAlignment="Left" Height="235" VerticalAlignment="Top" Width="233" Margin="0,6,0,0" >
             
             <UniformGrid.Resources>

--- a/Scrabble/View/MobileWindow.xaml
+++ b/Scrabble/View/MobileWindow.xaml
@@ -9,11 +9,14 @@
         ResizeMode="CanMinimize"
         >
 
-    <Grid>
-        <Button x:Name="ValidateButton"  FontSize="15" Background="Green" Foreground="White" IsEnabled="True" Content="DONE" HorizontalAlignment="Left" Margin="151,243,0,0" VerticalAlignment="Top" Width="69" Height="24" Click="ValidateButton_Click"/>
-        <Button x:Name="SwapButton" FontSize="15" Background="Tomato" Foreground="White" IsEnabled="True" Content="SWAP" HorizontalAlignment="Left" Margin="12,243,0,0" VerticalAlignment="Top" Width="70" Height="24" Click="SwapButton_Click"/>
-        <Button x:Name="ReloadButton" FontSize="15" Background="PaleVioletRed" Foreground="White" IsEnabled="True" Content="RELOAD" HorizontalAlignment="Left" Margin="82,243,0,0" VerticalAlignment="Top" Width="69" Height="24" Click="ReloadButton_Click"/>
-        <UniformGrid x:Name="BoardGrid" Columns="15" Rows="15" HorizontalAlignment="Left" Height="235" VerticalAlignment="Top" Width="233" Margin="0,6,0,0">
+    <Grid Margin="-1,1,1,-1" RenderTransformOrigin="0.844,0.686">
+        
+        <Button x:Name="ValidateButton"  FontSize="15" Background="Green" Foreground="White" IsEnabled="True" Content="DONE" HorizontalAlignment="Left" Margin="130,243,0,0" VerticalAlignment="Top" Width="50" Height="24" Click="ValidateButton_Click"/>
+        <Button x:Name="SwapButton" FontSize="15" Background="Tomato" Foreground="White" IsEnabled="True" Content="SWAP" HorizontalAlignment="Left" Margin="12,243,0,0" VerticalAlignment="Top" Width="50" Height="24" Click="SwapButton_Click"/>
+        <Button x:Name="ReloadButton" FontSize="15" Background="PaleVioletRed" Foreground="White" IsEnabled="True" Content="RELOAD" HorizontalAlignment="Left" Margin="67,243,0,0" VerticalAlignment="Top" Width="58" Height="24" Click="ReloadButton_Click"/>
+        <Button x:Name="HelpButton" Width="25" Height="24" FontSize="15" Background="Blue" Foreground="White" Margin="180,243,30,0" IsEnabled="True" VerticalAlignment="Top" FontFamily="Segoe MDL2 Assets" Content="&#xE897;" RenderTransformOrigin="1.9,-1.965" Click="HelpButton_Click"/>
+        <UniformGrid x:Name="BoardGrid" Columns="15" Rows="15" HorizontalAlignment="Left" Height="235" VerticalAlignment="Top" Width="233" Margin="0,6,0,0" >
+            
             <UniformGrid.Resources>
                 <Style TargetType="{x:Type Button}">
                     <Setter Property="Margin" Value="0.5"/>

--- a/Scrabble/View/MobileWindow.xaml.cs
+++ b/Scrabble/View/MobileWindow.xaml.cs
@@ -6,6 +6,7 @@ using System.Windows.Media;
 using Scrabble.View;
 using Scrabble.Model;
 using Scrabble.Controller;
+using System.Diagnostics;
 
 namespace Scrabble
 {
@@ -337,5 +338,26 @@ namespace Scrabble
             WriteToLabel(null);
         }
 
+        private void HelpButton_Click(object sender, RoutedEventArgs e)
+        {
+            bool isfound = false;
+            foreach (var item in Application.Current.Windows)
+            {
+                Debug.WriteLine(item.GetType());
+                if (item.GetType()==typeof(MobileHelpWindow))
+                {
+                    ((MobileHelpWindow)item).Top = (System.Windows.SystemParameters.WorkArea.Height / 2)-(((MobileHelpWindow)item).Height/2);
+                    ((MobileHelpWindow)item).Left = (System.Windows.SystemParameters.WorkArea.Width / 2) - (((MobileHelpWindow)item).Width / 2); 
+                    ((MobileHelpWindow)item).Topmost=false;
+                    ((MobileHelpWindow)item).Topmost = true;
+                    return;
+                }
+            }
+            if (!isfound)
+            {
+                MobileHelpWindow hw = new MobileHelpWindow();
+                hw.Show();
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixed the issue where the  desktop help window displayed the user was unable to interact with main window,.  Added the ability to only open one copy of that window and center it on te screen when displayed.  Added tooltips to mobile help widnow so users could see or get information about the tiles displayed